### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/darkace1998/jw-scripts/security/code-scanning/1](https://github.com/darkace1998/jw-scripts/security/code-scanning/1)

To fix this problem, the workflow should explicitly set the minimal permissions required by all jobs—usually at the top (root) level for simplicity and coverage. Since none of the jobs appear to require repository write access, you should add a `permissions: contents: read` block after the `name:` and before the `on:` blocks in the workflow file. This ensures that the GITHUB_TOKEN for all jobs only has read access to repository contents unless more specific permissions are set at an individual job level. No other changes are required since there are no steps indicating a need for higher privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
