### PR TITLE
Fix 13 bugs found during deep code review and functional testing

### DIFF
--- a/cmd/jwb-books/main.go
+++ b/cmd/jwb-books/main.go
@@ -194,10 +194,15 @@ func handleSearch(client *books.Client, language, query string) {
 			fmt.Printf("  Issue: %s\n", book.Issue)
 		}
 
-		// List available formats
+		// List available formats (deduplicated)
+		seen := make(map[string]bool)
 		var formats []string
 		for _, file := range book.Files {
-			formats = append(formats, string(file.Format))
+			f := string(file.Format)
+			if !seen[f] {
+				seen[f] = true
+				formats = append(formats, f)
+			}
 		}
 		if len(formats) > 0 {
 			fmt.Printf("  Available formats: %s\n", strings.Join(formats, ", "))

--- a/cmd/jwb-index/main.go
+++ b/cmd/jwb-index/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 var settings = &config.Settings{}
+var sinceDate string
 
 var rootCmd = &cobra.Command{
 	Use:   "jwb-index",
@@ -58,7 +59,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&settings.Quality, "quality", "Q", 720, "maximum video quality")
 	rootCmd.Flags().IntVarP(&settings.Quiet, "quiet", "q", 0, "less info, can be used multiple times")
 	rootCmd.Flags().BoolVar(&settings.SafeFilenames, "safe-filenames", runtime.GOOS == "windows", "use filesystem-safe filenames (automatically enabled on Windows)")
-	rootCmd.Flags().Int64Var(&settings.MinDate, "since", 0, "only index media newer than this date (YYYY-MM-DD)")
+	rootCmd.Flags().StringVar(&sinceDate, "since", "", "only index media newer than this date (YYYY-MM-DD)")
 	rootCmd.Flags().StringVar(&settings.Sort, "sort", "", "sort output (newest, oldest, name, random)")
 	rootCmd.Flags().BoolVar(&settings.Update, "update", false, "update existing categories with the latest videos")
 }
@@ -135,6 +136,15 @@ func run(s *config.Settings) error {
 		}
 	}
 
+	// Parse --since date if provided
+	if sinceDate != "" {
+		t, err := time.Parse("2006-01-02", sinceDate)
+		if err != nil {
+			return fmt.Errorf("invalid --since date %q (expected YYYY-MM-DD): %w", sinceDate, err)
+		}
+		s.MinDate = t.Unix()
+	}
+
 	if s.Latest {
 		// Set date range for 31-day window: from today back to 31 days ago when --latest flag is used
 		now := time.Now()
@@ -158,6 +168,9 @@ func run(s *config.Settings) error {
 		// Run mode is handled by the output.CreateOutput function
 		// which will use the CommandWriter to execute the configured command
 	}
+
+	// Convert MiB to bytes for disk space calculations
+	s.KeepFree *= 1024 * 1024
 
 	if s.WorkDir == "" {
 		s.WorkDir = "."

--- a/cmd/jwb-music/main.go
+++ b/cmd/jwb-music/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/darkace1998/jw-scripts/internal/api"
 	"github.com/darkace1998/jw-scripts/internal/config"
@@ -16,6 +17,7 @@ import (
 )
 
 var settings = &config.Settings{}
+var sinceDate string
 
 // musicCategories defines all the music-related categories available for download
 var musicCategories = []string{
@@ -75,7 +77,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&settings.Warning, "no-warning", true, "do not warn when space limit seems wrong")
 	rootCmd.Flags().IntVarP(&settings.Quiet, "quiet", "q", 0, "less info, can be used multiple times")
 	rootCmd.Flags().BoolVar(&settings.SafeFilenames, "safe-filenames", runtime.GOOS == "windows", "use filesystem-safe filenames (automatically enabled on Windows)")
-	rootCmd.Flags().Int64Var(&settings.MinDate, "since", 0, "only index music newer than this date (YYYY-MM-DD)")
+	rootCmd.Flags().StringVar(&sinceDate, "since", "", "only index music newer than this date (YYYY-MM-DD)")
 	rootCmd.Flags().StringVar(&settings.Sort, "sort", "", "sort output (newest, oldest, name, random)")
 	rootCmd.Flags().BoolVar(&settings.Update, "update", false, "update existing categories with the latest music")
 }
@@ -131,6 +133,18 @@ func run(s *config.Settings) error {
 			s.Sort = "newest"
 		}
 	}
+
+	// Parse --since date if provided
+	if sinceDate != "" {
+		t, err := time.Parse("2006-01-02", sinceDate)
+		if err != nil {
+			return fmt.Errorf("invalid --since date %q (expected YYYY-MM-DD): %w", sinceDate, err)
+		}
+		s.MinDate = t.Unix()
+	}
+
+	// Convert MiB to bytes for disk space calculations
+	s.KeepFree *= 1024 * 1024
 
 	if s.WorkDir == "" {
 		s.WorkDir = "./music"

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,7 +31,13 @@ const (
 	// subtitleMatchBonus is the ranking bonus applied when a video's subtitle
 	// state matches the requested preference.
 	subtitleMatchBonus = 100
+
+	// maxResponseSize is the maximum allowed API response body size (10 MiB).
+	maxResponseSize = 10 << 20
 )
+
+// parseDateMillisRegex strips milliseconds from date strings for fallback parsing.
+var parseDateMillisRegex = regexp.MustCompile(`\.\d+Z$`)
 
 // Client is a client for the JW.ORG API.
 type Client struct {
@@ -64,7 +71,7 @@ func (c *Client) GetLanguages() ([]Language, error) {
 	}
 
 	var langResp LanguagesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&langResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&langResp); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +92,7 @@ func (c *Client) GetRootCategories() ([]string, error) {
 	}
 
 	var rootResp RootCategoriesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&rootResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&rootResp); err != nil {
 		return nil, err
 	}
 
@@ -140,7 +147,7 @@ func (c *Client) GetCategory(lang, key string) (*CategoryResponse, error) {
 	}
 
 	var catResp CategoryResponse
-	if err := json.NewDecoder(resp.Body).Decode(&catResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&catResp); err != nil {
 		return nil, err
 	}
 
@@ -250,7 +257,7 @@ func (c *Client) fetchPubMediaMP3s(pubCode string) ([]PubMediaFile, error) {
 	}
 
 	var pubResp PubMediaResponse
-	if err := json.NewDecoder(resp.Body).Decode(&pubResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&pubResp); err != nil {
 		return nil, err
 	}
 
@@ -335,21 +342,21 @@ func (c *Client) ParseBroadcasting() ([]*Category, error) {
 
 			var bestFile *File
 
-switch {
-		case m.Type == "audio":
-			if len(m.Files) > 0 {
-				bestFile = &m.Files[0]
-			}
-		case c.settings.AudioOnly:
-			// When audio-only mode is enabled, try to find an audio file
-			bestFile = getBestAudio(m.Files)
-			if bestFile == nil {
-				if c.settings.Quiet < 1 {
-					fmt.Fprintf(os.Stderr, "no audio files found for: %s (skipping video-only content)\n", m.Title)
+			switch {
+			case m.Type == "audio":
+				if len(m.Files) > 0 {
+					bestFile = &m.Files[0]
 				}
-				continue
-			}
-		default:
+			case c.settings.AudioOnly:
+				// When audio-only mode is enabled, try to find an audio file
+				bestFile = getBestAudio(m.Files)
+				if bestFile == nil {
+					if c.settings.Quiet < 1 {
+						fmt.Fprintf(os.Stderr, "no audio files found for: %s (skipping video-only content)\n", m.Title)
+					}
+					continue
+				}
+			default:
 				bestFile = getBestVideo(m.Files, c.settings.Quality, c.settings.HardSubtitles)
 			}
 
@@ -474,8 +481,7 @@ func parseDate(dateString string) (time.Time, error) {
 		return t.UTC(), nil
 	}
 	// Strip milliseconds and parse as UTC
-	re := regexp.MustCompile(`\.\d+Z$`)
-	dateString = re.ReplaceAllString(dateString, "")
+	dateString = parseDateMillisRegex.ReplaceAllString(dateString, "")
 	t, err := time.Parse("2006-01-02T15:04:05", dateString)
 	if err != nil {
 		return time.Time{}, err

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -20,9 +20,10 @@ import (
 const (
 	baseURL     = "https://data.jw-api.org/mediator/v1"
 	pubMediaURL = "https://b.jw-cdn.org/apis/pub-media/GETPUBMEDIALINKS"
-	// jwbYearBase is subtracted from the current year to derive the JWB issue number.
-	// For example, 2026 - 1892 = 134 (i.e. jwb-134).
-	jwbYearBase = 1892
+	// jwbStartYear and jwbStartMonth mark when JW Broadcasting began (October 2014 = issue 1).
+	// Issue numbers are sequential months: issue = (year-2014)*12 + month - 10 + 1
+	jwbStartYear  = 2014
+	jwbStartMonth = 10
 
 	// qualityMatchBonus is the ranking bonus applied when a video resolution
 	// is within the requested quality limit.
@@ -166,10 +167,11 @@ func (c *Client) GetBroadcastingMP3s() ([]*Category, error) {
 		Home: true,
 	}
 
-	// Search through recent JWB issues (going back about 3 years)
-	// Each jwb-NNN publication contains monthly programs for that year
-	startIssue := time.Now().Year() - jwbYearBase
-	endIssue := startIssue - 10 // Go back about 10 years worth of issues
+	// Compute the current JWB issue number. Issues are numbered sequentially by
+	// month starting from October 2014 (issue 1). Going back 36 issues = 3 years.
+	now := time.Now()
+	startIssue := (now.Year()-jwbStartYear)*12 + int(now.Month()) - jwbStartMonth + 1
+	endIssue := startIssue - 36 // Go back 3 years worth of monthly issues
 
 	for issue := startIssue; issue >= endIssue; issue-- {
 		pubCode := fmt.Sprintf("jwb-%d", issue)

--- a/internal/books/client.go
+++ b/internal/books/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -192,6 +193,10 @@ func (c *Client) GetBook(lang, bookID string) (*Book, error) {
 					Size:     fileInfo.FileSize,
 					Checksum: fileInfo.File.Checksum,
 					Title:    fileInfo.Title,
+				}
+				// Extract filename from URL since the API doesn't provide one directly
+				if u, err := url.Parse(fileInfo.File.URL); err == nil {
+					bookFile.Filename = path.Base(u.Path)
 				}
 				book.Files = append(book.Files, bookFile)
 			}

--- a/internal/books/client.go
+++ b/internal/books/client.go
@@ -218,14 +218,20 @@ func (c *Client) SearchBooks(lang, query string) ([]Book, error) {
 	queryLower := strings.ToLower(query)
 
 	for _, category := range categories {
+		// Check if query matches the category name or key
+		categoryMatch := strings.Contains(strings.ToLower(category.Name), queryLower) ||
+			strings.Contains(strings.ToLower(category.Key), queryLower) ||
+			strings.Contains(strings.ToLower(category.Description), queryLower)
+
 		for _, pubCode := range category.Publications {
 			book, err := c.GetBook(lang, pubCode)
 			if err != nil {
 				continue
 			}
 
-			// Simple text matching
-			if strings.Contains(strings.ToLower(book.Title), queryLower) ||
+			// Match on book title, description, or parent category
+			if categoryMatch ||
+				strings.Contains(strings.ToLower(book.Title), queryLower) ||
 				strings.Contains(strings.ToLower(book.Description), queryLower) {
 				results = append(results, *book)
 			}

--- a/internal/books/downloader.go
+++ b/internal/books/downloader.go
@@ -46,7 +46,7 @@ func (d *Downloader) DownloadBook(book *Book, format BookFormat, outputDir strin
 
 	// Create output directory if it doesn't exist
 	if err := os.MkdirAll(outputDir, 0o750); err != nil {
-		return fmt.Errorf("failed to create output directory: %v", err)
+		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	// Determine output file path
@@ -70,7 +70,7 @@ func (d *Downloader) DownloadBook(book *Book, format BookFormat, outputDir strin
 
 	// Ensure the parent directory exists
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
-		return fmt.Errorf("failed to create parent directory for %s: %v", outputPath, err)
+		return fmt.Errorf("failed to create parent directory for %s: %w", outputPath, err)
 	}
 
 	return downloader.DownloadFile(targetFile.URL, outputPath, false, d.settings.RateLimit)
@@ -92,7 +92,7 @@ func (d *Downloader) DownloadCategory(category *BookCategory, format BookFormat,
 	// Create category subdirectory
 	categoryDir := filepath.Join(outputDir, category.Key)
 	if err := os.MkdirAll(categoryDir, 0o750); err != nil {
-		return fmt.Errorf("failed to create category directory: %v", err)
+		return fmt.Errorf("failed to create category directory: %w", err)
 	}
 
 	successCount := 0
@@ -132,13 +132,13 @@ func (d *Downloader) ValidateChecksum(filePath, expectedChecksum string) error {
 	// #nosec G304 - Path is for file checksum verification in download process
 	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file for checksum validation: %v", err)
+		return fmt.Errorf("failed to open file for checksum validation: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 
 	hash := md5.New() // #nosec G401 - MD5 used for file integrity verification, not cryptographic security
 	if _, err := io.Copy(hash, file); err != nil {
-		return fmt.Errorf("failed to compute checksum: %v", err)
+		return fmt.Errorf("failed to compute checksum: %w", err)
 	}
 	actualChecksum := hex.EncodeToString(hash.Sum(nil))
 	// Compare checksums case-insensitively

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -265,10 +265,13 @@ func DownloadFile(rawURL, path string, resume bool, rateLimit float64) error {
 	}
 
 	var out *os.File
-	if resume {
+	if resume && resp.StatusCode == http.StatusPartialContent {
+		// Server supports range requests; append to existing file
 		// #nosec G304 - Path is from download logic for legitimate file operations
 		out, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	} else {
+		// Server returned full content (200) or fresh download; truncate and write from start
+		start = 0
 		// #nosec G304 - Path is from download logic for legitimate file operations
 		out, err = os.Create(path)
 	}
@@ -278,6 +281,10 @@ func DownloadFile(rawURL, path string, resume bool, rateLimit float64) error {
 	defer func() { _ = out.Close() }()
 
 	size := resp.ContentLength + start
+	if resp.ContentLength < 0 {
+		// Unknown content length; use -1 to indicate indeterminate progress
+		size = -1
+	}
 
 	bar := progressbar.NewOptions64(
 		size,
@@ -407,7 +414,7 @@ func getOldestMP4(directory string) (os.FileInfo, error) {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	return !os.IsNotExist(err)
+	return err == nil
 }
 
 // throttledReader is a reader that is throttled to a certain rate.

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -90,6 +90,9 @@ func outputSingle(s *config.Settings, data []*api.Category, writer Writer) error
 }
 
 func outputMulti(s *config.Settings, data []*api.Category, writer Writer) error {
+	originalFilename := s.OutputFilename
+	defer func() { s.OutputFilename = originalFilename }()
+
 	for _, category := range data {
 		var categoryMedia []*api.Media
 		for _, item := range category.Contents {
@@ -110,7 +113,6 @@ func outputMulti(s *config.Settings, data []*api.Category, writer Writer) error 
 		sortMedia(categoryMedia, s.Sort)
 
 		// Create separate output file for each category
-		originalFilename := s.OutputFilename
 		if originalFilename == "" {
 			s.OutputFilename = fmt.Sprintf("%s.%s", category.Key, getDefaultExtension(s.Mode))
 		} else {
@@ -132,12 +134,10 @@ func outputMulti(s *config.Settings, data []*api.Category, writer Writer) error 
 			categoryWriter, err = NewHTMLWriter(s)
 		default:
 			// For stdout and run modes, we can't really do "multi" so just use single output
-			s.OutputFilename = originalFilename
 			return outputSingle(s, data, writer)
 		}
 
 		if err != nil {
-			s.OutputFilename = originalFilename
 			return err
 		}
 
@@ -154,12 +154,8 @@ func outputMulti(s *config.Settings, data []*api.Category, writer Writer) error 
 		}
 
 		if err := categoryWriter.Dump(); err != nil {
-			s.OutputFilename = originalFilename
 			return err
 		}
-
-		// Restore original filename
-		s.OutputFilename = originalFilename
 	}
 
 	return nil
@@ -259,7 +255,7 @@ func sortMedia(mediaList []*api.Media, sortKey string) {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	return !os.IsNotExist(err)
+	return err == nil
 }
 
 // --- TxtWriter ---


### PR DESCRIPTION
## Summary

This PR fixes **13 bugs** discovered during a deep code review and functional testing of all CLI tools. All changes pass `go build ./...`, `go test ./...`, and `golangci-lint run ./...` (0 issues) with Go 1.25.

---

## Bug Fixes

### Critical
- **Resume download data corruption** — When a server returns HTTP 200 instead of 206 (Partial Content), the old code appended the full response body to the existing partial file, corrupting it. Now detects the status code and truncates to restart cleanly.
- **`--free` flag MiB→bytes conversion missing** — The flag is documented as MiB but was compared directly to bytes from `getFreeDiskSpace()`, making disk cleanup essentially never trigger. Fixed in both `jwb-index` and `jwb-music`.
- **`BookFile.Filename` never populated** — The field was always empty, always falling through to a title-based fallback filename. Now extracts the real filename from the download URL.

### Functional
- **`--since` flag type mismatch** — Help text says `YYYY-MM-DD` but the flag was an `Int64Var` expecting a raw Unix timestamp. Changed to a string flag with proper date parsing and clear error messages.
- **Progress bar broken with unknown content length** — When `ContentLength` is `-1`, the arithmetic produced a wrong total. Now passes `-1` to indicate indeterminate progress.
- **Book search didn't match category names** — Searching for "bible" returned nothing because only `book.Title`/`book.Description` were checked. Fixed to also match category name/key/description.
- **Duplicate formats in book search results** — Search displayed "pdf, pdf, epub, rtf, rtf…". Added deduplication.

### Robustness
- **`outputMulti` unsafe Settings mutation** — Replaced fragile manual save/restore of `Settings.OutputFilename` with a single `defer`.
- **API response body unbounded** — Added `io.LimitReader(resp.Body, 10 MiB)` to all 4 JSON decode sites in `internal/api/client.go`.
- **Error wrapping inconsistency** — Changed `%v` → `%w` in `books/downloader.go`.

### Code Quality
- **`parseDate` recompiles regex on every call** — Moved `regexp.MustCompile` to a package-level var.
- **`ParseBroadcasting` broken indentation** — Fixed switch/case formatting.

---

## Testing
- `go build ./...` ✅
- `go test ./...` ✅ (all 18 packages)
- `golangci-lint run ./...` ✅ (0 issues, Go 1.25)
- Manual functional tests against live JW.org API ✅